### PR TITLE
Refactor file state to ViewModel

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -74,6 +74,8 @@ dependencies {
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-play-services:1.4.1")
     implementation("io.coil-kt:coil-compose:2.2.2")
     implementation("androidx.compose.material3:material3-android:1.3.1")
+    implementation("androidx.lifecycle:lifecycle-viewmodel-ktx:2.6.2")
+    implementation("androidx.lifecycle:lifecycle-viewmodel-compose:2.6.2")
 
     androidTestImplementation(platform("androidx.compose:compose-bom:2023.08.00"))
     androidTestImplementation("androidx.compose.ui:ui-test-junit4")

--- a/app/src/main/java/com/wearconnectivityexample/data/FileState.kt
+++ b/app/src/main/java/com/wearconnectivityexample/data/FileState.kt
@@ -1,9 +1,0 @@
-package com.wearconnectivityexample.data
-
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.setValue
-
-object FileState {
-    var imagePath: String? by mutableStateOf(null)
-}

--- a/app/src/main/java/com/wearconnectivityexample/data/FileViewModel.kt
+++ b/app/src/main/java/com/wearconnectivityexample/data/FileViewModel.kt
@@ -1,0 +1,40 @@
+package com.wearconnectivityexample.data
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+
+/**
+ * ViewModel responsible for holding the path of the image received from the
+ * connected device. The state is exposed as a [StateFlow] so that UI elements
+ * can reactively update when the image changes.
+ */
+class FileViewModel : ViewModel() {
+    private val _imagePath = MutableStateFlow<String?>(null)
+    val imagePath: StateFlow<String?> = _imagePath
+
+    fun setImagePath(path: String?) {
+        _imagePath.value = path
+    }
+}
+
+/**
+ * Simple factory that returns a single instance of [FileViewModel].
+ * This allows components like composables and services to obtain the same
+ * ViewModel without relying on a full DI framework.
+ */
+object FileViewModelFactory : ViewModelProvider.Factory {
+    private val viewModel = FileViewModel()
+
+    override fun <T : ViewModel> create(modelClass: Class<T>): T {
+        if (modelClass.isAssignableFrom(FileViewModel::class.java)) {
+            @Suppress("UNCHECKED_CAST")
+            return viewModel as T
+        }
+        throw IllegalArgumentException("Unknown ViewModel class")
+    }
+
+    fun get(): FileViewModel = viewModel
+}
+

--- a/app/src/main/java/com/wearconnectivityexample/service/WearDataListenerService.kt
+++ b/app/src/main/java/com/wearconnectivityexample/service/WearDataListenerService.kt
@@ -7,10 +7,11 @@ import com.google.android.gms.wearable.DataEventBuffer
 import com.google.android.gms.wearable.DataMapItem
 import com.google.android.gms.wearable.Wearable
 import com.google.android.gms.wearable.WearableListenerService
-import com.wearconnectivityexample.data.FileState
+import com.wearconnectivityexample.data.FileViewModelFactory
 import java.io.File
 
 class WearDataListenerService : WearableListenerService() {
+    private val fileViewModel = FileViewModelFactory.get()
     override fun onDataChanged(dataEvents: DataEventBuffer) {
         for (event in dataEvents) {
             if (event.type == DataEvent.TYPE_CHANGED) {
@@ -36,7 +37,7 @@ class WearDataListenerService : WearableListenerService() {
                     inputStream.copyTo(outputStream)
                 }
                 // Update the shared state (ensure this runs on the main thread)
-                FileState.imagePath = file.absolutePath
+                fileViewModel.setImagePath(file.absolutePath)
             }
             Log.w("WearOS", "File transfer successful")
         }.addOnFailureListener { e ->

--- a/app/src/main/java/com/wearconnectivityexample/ui/components/ImageViewer.kt
+++ b/app/src/main/java/com/wearconnectivityexample/ui/components/ImageViewer.kt
@@ -3,6 +3,7 @@ package com.wearconnectivityexample.ui.components
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.*
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
@@ -12,12 +13,14 @@ import androidx.wear.compose.material.Button
 import androidx.wear.compose.material.Text
 import coil.compose.rememberAsyncImagePainter
 import java.io.File
-import com.wearconnectivityexample.data.FileState
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.wearconnectivityexample.data.FileViewModel
+import com.wearconnectivityexample.data.FileViewModelFactory
 
 @Composable
-fun ImageViewer() {
+fun ImageViewer(fileViewModel: FileViewModel = viewModel(factory = FileViewModelFactory)) {
     val context = LocalContext.current
-    val imagePath = FileState.imagePath
+    val imagePath = fileViewModel.imagePath.collectAsState().value
 
     Box(modifier = Modifier.fillMaxSize()) {
         if (imagePath != null && File(imagePath).exists()) {
@@ -44,7 +47,7 @@ fun ImageViewer() {
                             val file = File(imagePath)
                             if (file.exists()) {
                                 file.delete()
-                                FileState.imagePath = null
+                                fileViewModel.setImagePath(null)
                             }
                         }
                     }, modifier = Modifier.padding(top = 16.dp, end = 90.dp)


### PR DESCRIPTION
## Summary
- manage image path via new FileViewModel with StateFlow
- update WearDataListenerService and ImageViewer to use FileViewModel
- remove legacy FileState and add lifecycle dependencies

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b16193312c83208b3263a51be6f1db