### PR TITLE
Release recorder resources when composable disposed

### DIFF
--- a/app/src/main/java/com/wearconnectivityexample/ui/screens/RecordVoiceScreen.kt
+++ b/app/src/main/java/com/wearconnectivityexample/ui/screens/RecordVoiceScreen.kt
@@ -47,6 +47,12 @@ fun RecordVoiceScreen(
     var isRecording by remember { mutableStateOf(false) }
     // Hold a reference to the MediaRecorder.
     var mediaRecorder by remember { mutableStateOf<MediaRecorder?>(null) }
+    DisposableEffect(Unit) {
+        onDispose {
+            mediaRecorder?.release()
+            mediaRecorder = null
+        }
+    }
     // Define the output file path; we use internal storage.
     val outputFile = remember { "${context.filesDir.absolutePath}/voice_message.mp3" }
 


### PR DESCRIPTION
## Summary
- release `MediaRecorder` in `RecordVoiceScreen` using a `DisposableEffect`

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b1619a97d48320865289398c03ef3c