### PR TITLE
Ensure FileState update occurs on main thread

### DIFF
--- a/app/src/main/java/com/wearconnectivityexample/service/WearDataListenerService.kt
+++ b/app/src/main/java/com/wearconnectivityexample/service/WearDataListenerService.kt
@@ -1,6 +1,8 @@
 package com.wearconnectivityexample.service
 
 import android.util.Log
+import android.os.Handler
+import android.os.Looper
 import com.google.android.gms.wearable.Asset
 import com.google.android.gms.wearable.DataEvent
 import com.google.android.gms.wearable.DataEventBuffer
@@ -25,7 +27,7 @@ class WearDataListenerService : WearableListenerService() {
         }
     }
 
-    fun saveReceivedFile(asset: Asset) {
+    private fun saveReceivedFile(asset: Asset) {
         val dataClient = Wearable.getDataClient(this)
         val task = dataClient.getFdForAsset(asset)
 
@@ -36,7 +38,9 @@ class WearDataListenerService : WearableListenerService() {
                     inputStream.copyTo(outputStream)
                 }
                 // Update the shared state (ensure this runs on the main thread)
-                FileState.imagePath = file.absolutePath
+                Handler(Looper.getMainLooper()).post {
+                    FileState.imagePath = file.absolutePath
+                }
             }
             Log.w("WearOS", "File transfer successful")
         }.addOnFailureListener { e ->


### PR DESCRIPTION
## Summary
- Make `saveReceivedFile` private in `WearDataListenerService`
- Post `FileState.imagePath` update to the main thread with a Handler

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b16187c23c83209a9056f8030aa1b6