### PR TITLE
Use File.readBytes for asset creation

### DIFF
--- a/app/src/main/java/com/wearconnectivityexample/ui/components/AudioRecorder.kt
+++ b/app/src/main/java/com/wearconnectivityexample/ui/components/AudioRecorder.kt
@@ -27,7 +27,6 @@ import com.google.android.gms.wearable.Asset
 import com.google.android.gms.wearable.PutDataMapRequest
 import com.google.android.gms.wearable.Wearable
 import java.io.File
-import java.io.FileInputStream
 import java.io.IOException
 import androidx.wear.compose.material.Icon
 import androidx.wear.compose.material.ToggleButton
@@ -100,11 +99,8 @@ fun sendVoiceMessage(context: Context, filePath: String) {
     val fileExtension = file.extension // Extract file type (e.g., "mp3", "wav")
     val dataClient = Wearable.getDataClient(context)
     val asset = try {
-        FileInputStream(file).use { fis ->
-            val bytes = ByteArray(file.length().toInt())
-            fis.read(bytes)
-            Asset.createFromBytes(bytes)
-        }
+        val bytes = file.readBytes()
+        Asset.createFromBytes(bytes)
     } catch (e: IOException) {
         Log.e("RecordVoiceScreen", "Error creating asset", e)
         return

--- a/app/src/main/java/com/wearconnectivityexample/ui/screens/RecordVoiceScreen.kt
+++ b/app/src/main/java/com/wearconnectivityexample/ui/screens/RecordVoiceScreen.kt
@@ -29,7 +29,6 @@ import com.google.android.gms.wearable.Asset
 import com.google.android.gms.wearable.PutDataMapRequest
 import com.google.android.gms.wearable.Wearable
 import java.io.File
-import java.io.FileInputStream
 import java.io.IOException
 import androidx.wear.compose.material.Icon
 import androidx.wear.compose.material.ToggleButton
@@ -105,11 +104,8 @@ fun sendVoiceMessage(context: Context, filePath: String) {
     val fileExtension = file.extension // Extract file type (e.g., "mp3", "wav")
     val dataClient = Wearable.getDataClient(context)
     val asset = try {
-        FileInputStream(file).use { fis ->
-            val bytes = ByteArray(file.length().toInt())
-            fis.read(bytes)
-            Asset.createFromBytes(bytes)
-        }
+        val bytes = file.readBytes()
+        Asset.createFromBytes(bytes)
     } catch (e: IOException) {
         Log.e("RecordVoiceScreen", "Error creating asset", e)
         return


### PR DESCRIPTION
## Summary
- build Asset from `file.readBytes()` in `sendVoiceMessage`
- remove unused `FileInputStream` imports

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b16167f0e8832091f1bd26ceccdac1