### PR TITLE
Localize recording icon content description

### DIFF
--- a/app/src/main/java/com/wearconnectivityexample/ui/screens/RecordVoiceScreen.kt
+++ b/app/src/main/java/com/wearconnectivityexample/ui/screens/RecordVoiceScreen.kt
@@ -20,6 +20,7 @@ import androidx.compose.ui.unit.dp
 import androidx.wear.compose.material.Chip
 import androidx.wear.compose.material.ChipDefaults
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.sp
 import androidx.wear.compose.material.Text
@@ -156,7 +157,7 @@ fun RecordComponent(onRecordClicked: () -> Unit, checked: Boolean) {
             ) {
                 Icon(
                     painter = painterResource(id = R.drawable.ic_mic),
-                    contentDescription = "airplane",
+                    contentDescription = stringResource(id = R.string.content_description_record),
                     modifier =
                     Modifier
                         .size(ToggleButtonDefaults.DefaultIconSize)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -5,4 +5,5 @@
     values-round/strings.xml for round devices.
     -->
     <string name="hello_world">0</string>
+    <string name="content_description_record">Record</string>
 </resources>


### PR DESCRIPTION
## Summary
- replace placeholder content description with localized string for recording icon
- add `content_description_record` string resource

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b1615ffdc083208474a839dfdd2b07