### PR TITLE
Remove unnecessary semicolons

### DIFF
--- a/app/src/main/java/com/wearconnectivityexample/ui/MainActivity.kt
+++ b/app/src/main/java/com/wearconnectivityexample/ui/MainActivity.kt
@@ -19,7 +19,7 @@ class MainActivity : ComponentActivity() {
 
     public override fun onStart() {
         super.onStart()
-        requestAudioPermission(this);
+        requestAudioPermission(this)
     }
 }
 

--- a/app/src/main/java/com/wearconnectivityexample/ui/screens/RecordVoiceScreen.kt
+++ b/app/src/main/java/com/wearconnectivityexample/ui/screens/RecordVoiceScreen.kt
@@ -79,7 +79,7 @@ fun RecordVoiceScreen(
             mediaRecorder = null
             isRecording = false
             sendVoiceMessage(context, outputFile)
-            onStopRecording();
+            onStopRecording()
         } catch (e: Exception) {
             Log.e("RecordVoiceScreen", "Error stopping recorder", e)
         }


### PR DESCRIPTION
## Summary
- Drop redundant semicolons in `MainActivity` and `RecordVoiceScreen`

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b160f822548320b27b20759c061da8