### PR TITLE
Clean up imports in chat and record screens

### DIFF
--- a/app/src/main/java/com/wearconnectivityexample/ui/screens/ChatListScreen.kt
+++ b/app/src/main/java/com/wearconnectivityexample/ui/screens/ChatListScreen.kt
@@ -1,10 +1,7 @@
+
 package com.wearconnectivityexample.ui.screens
 
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.*
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ChatBubble
 import androidx.compose.runtime.Composable
@@ -18,7 +15,6 @@ import androidx.wear.compose.material.Chip
 import androidx.wear.compose.material.ChipDefaults
 import androidx.wear.compose.material.Icon
 import androidx.wear.compose.material.Text
-import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.filled.ArrowUpward
 import androidx.compose.ui.Alignment

--- a/app/src/main/java/com/wearconnectivityexample/ui/screens/RecordVoiceScreen.kt
+++ b/app/src/main/java/com/wearconnectivityexample/ui/screens/RecordVoiceScreen.kt
@@ -6,8 +6,6 @@ import android.util.Log
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.wrapContentSize
@@ -17,8 +15,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
-import androidx.wear.compose.material.Chip
-import androidx.wear.compose.material.ChipDefaults
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.sp
@@ -32,9 +28,7 @@ import java.io.File
 import java.io.FileInputStream
 import java.io.IOException
 import androidx.wear.compose.material.Icon
-import androidx.wear.compose.material.ToggleButton
 import com.wearconnectivityexample.R
-import androidx.wear.compose.material.Text
 import com.google.android.gms.wearable.DataMap
 
 @Composable


### PR DESCRIPTION
## Summary
- consolidate layout imports in `ChatListScreen`
- remove duplicate and unused imports in `RecordVoiceScreen`

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b160f0f034832096ba35c8c301859a