### PR TITLE
Align UI package names

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -26,7 +26,7 @@
             android:value="true" />
 
         <activity
-            android:name="com.example.wearconnectivityexample.ui.MainActivity"
+            android:name="com.wearconnectivityexample.ui.MainActivity"
             android:exported="true"
             android:taskAffinity=""
             android:theme="@style/MainActivityTheme.Starting">
@@ -38,7 +38,7 @@
         </activity>
 
         <service
-            android:name="com.example.wearconnectivityexample.ui.MainActivity"
+            android:name="com.wearconnectivityexample.ui.MainActivity"
             android:exported="true">
             <intent-filter>
                 <!-- listeners receive events that match the action and data filters -->

--- a/app/src/main/java/com/wearconnectivityexample/ui/MainActivity.kt
+++ b/app/src/main/java/com/wearconnectivityexample/ui/MainActivity.kt
@@ -1,4 +1,4 @@
-package com.example.wearconnectivityexample.ui
+package com.wearconnectivityexample.ui
 
 import android.os.Bundle
 import androidx.activity.ComponentActivity

--- a/app/src/main/java/com/wearconnectivityexample/ui/WearApp.kt
+++ b/app/src/main/java/com/wearconnectivityexample/ui/WearApp.kt
@@ -1,14 +1,14 @@
 // WearApp.kt
-package com.example.wearconnectivityexample.ui
+package com.wearconnectivityexample.ui
 
 import androidx.compose.runtime.Composable
-import androidx.wear.compose.navigation.rememberSwipeDismissableNavController
 import androidx.wear.compose.navigation.SwipeDismissableNavHost
 import androidx.wear.compose.navigation.composable
+import androidx.wear.compose.navigation.rememberSwipeDismissableNavController
 import androidx.navigation.navArgument
-import com.example.mywearosapp.ui.screens.ChatDetailScreen
-import com.example.wearconnectivityexample.ui.screens.RecordVoiceScreen
+import com.wearconnectivityexample.ui.screens.ChatDetailScreen
 import com.wearconnectivityexample.ui.screens.ChatListScreen
+import com.wearconnectivityexample.ui.screens.RecordVoiceScreen
 
 @Composable
 fun WearApp() {

--- a/app/src/main/java/com/wearconnectivityexample/ui/components/AudioRecorder.kt
+++ b/app/src/main/java/com/wearconnectivityexample/ui/components/AudioRecorder.kt
@@ -1,3 +1,5 @@
+package com.wearconnectivityexample.ui.components
+
 import android.content.Context
 import android.media.MediaRecorder
 import android.util.Log

--- a/app/src/main/java/com/wearconnectivityexample/ui/screens/ChatDetailScreen.kt
+++ b/app/src/main/java/com/wearconnectivityexample/ui/screens/ChatDetailScreen.kt
@@ -1,4 +1,4 @@
-package com.example.mywearosapp.ui.screens
+package com.wearconnectivityexample.ui.screens
 
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.RoundedCornerShape

--- a/app/src/main/java/com/wearconnectivityexample/ui/screens/RecordVoiceScreen.kt
+++ b/app/src/main/java/com/wearconnectivityexample/ui/screens/RecordVoiceScreen.kt
@@ -1,4 +1,4 @@
-package com.example.wearconnectivityexample.ui.screens
+package com.wearconnectivityexample.ui.screens
 
 import android.content.Context
 import android.media.MediaRecorder


### PR DESCRIPTION
## Summary
- Use `com.wearconnectivityexample.ui` for MainActivity and WearApp
- Move ChatDetailScreen and RecordVoiceScreen into `com.wearconnectivityexample.ui.screens`
- Add missing package declaration for AudioRecorder and fix imports

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b160c74ed4832080f15bdd9d8ca9bd