### PR TITLE
Add menu navigation screen with new routes

### DIFF
--- a/app/src/main/java/com/wearconnectivityexample/ui/WearApp.kt
+++ b/app/src/main/java/com/wearconnectivityexample/ui/WearApp.kt
@@ -9,6 +9,8 @@ import androidx.navigation.navArgument
 import com.example.mywearosapp.ui.screens.ChatDetailScreen
 import com.example.wearconnectivityexample.ui.screens.RecordVoiceScreen
 import com.wearconnectivityexample.ui.screens.ChatListScreen
+import com.wearconnectivityexample.ui.screens.MenuScreen
+import com.wearconnectivityexample.ui.screens.CounterScreen
 
 @Composable
 fun WearApp() {
@@ -16,14 +18,28 @@ fun WearApp() {
 
     SwipeDismissableNavHost(
         navController = navController,
-        startDestination = "chatList"
+        startDestination = "menu"
     ) {
-        composable("chatList") {
+        composable("menu") {
+            MenuScreen(navController)
+        }
+        composable("chatroom") {
             ChatListScreen(
                 onChatSelected = { phoneNumber ->
                     navController.navigate("chatDetail/$phoneNumber")
                 }
             )
+        }
+        composable("sendFile") {
+            RecordVoiceScreen(
+                onStopRecording = {
+                    // Go back to the previous screen, or handle differently
+                    navController.popBackStack()
+                }
+            )
+        }
+        composable("counter") {
+            CounterScreen()
         }
         composable(
             route = "chatDetail/{phoneNumber}",
@@ -32,15 +48,7 @@ fun WearApp() {
             val phoneNumber = backStackEntry.arguments?.getString("phoneNumber") ?: ""
             ChatDetailScreen(
                 phoneNumber = phoneNumber,
-                onRecordClick = { navController.navigate("recordVoice") }
-            )
-        }
-        composable("recordVoice") {
-            RecordVoiceScreen(
-                onStopRecording = {
-                    // Go back to the previous screen, or handle differently
-                    navController.popBackStack()
-                }
+                onRecordClick = { navController.navigate("sendFile") }
             )
         }
     }

--- a/app/src/main/java/com/wearconnectivityexample/ui/screens/CounterScreen.kt
+++ b/app/src/main/java/com/wearconnectivityexample/ui/screens/CounterScreen.kt
@@ -1,0 +1,29 @@
+package com.wearconnectivityexample.ui.screens
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.wear.compose.material.Chip
+import androidx.wear.compose.material.Text
+
+@Composable
+fun CounterScreen() {
+    var count by remember { mutableStateOf(0) }
+
+    Box(
+        modifier = Modifier.fillMaxSize(),
+        contentAlignment = Alignment.Center
+    ) {
+        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+            Text(text = "Count: $count")
+            Chip(onClick = { count++ }, label = { Text("Increment") })
+        }
+    }
+}

--- a/app/src/main/java/com/wearconnectivityexample/ui/screens/MenuScreen.kt
+++ b/app/src/main/java/com/wearconnectivityexample/ui/screens/MenuScreen.kt
@@ -1,0 +1,32 @@
+package com.wearconnectivityexample.ui.screens
+
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.navigation.NavHostController
+import androidx.wear.compose.foundation.lazy.ScalingLazyColumn
+import androidx.wear.compose.foundation.lazy.items
+import androidx.wear.compose.material.Chip
+import androidx.wear.compose.material.Text
+
+@Composable
+fun MenuScreen(navController: NavHostController) {
+    val items = listOf(
+        "Chatroom" to "chatroom",
+        "Send File" to "sendFile",
+        "Counter" to "counter"
+    )
+
+    ScalingLazyColumn(
+        modifier = Modifier.fillMaxSize()
+    ) {
+        items(items) { (label, route) ->
+            Chip(
+                onClick = { navController.navigate(route) },
+                label = { Text(label) },
+                modifier = Modifier.fillMaxWidth()
+            )
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add menu screen listing Chatroom, Send File, and Counter options
- add simple counter screen
- wire up navigation with new start destination and routes

## Testing
- `./gradlew build` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b70779fb48832095586214dfb07138