### PR TITLE
Add navigation menu and extra screens with back navigation

### DIFF
--- a/app/src/main/java/com/wearconnectivityexample/ui/WearApp.kt
+++ b/app/src/main/java/com/wearconnectivityexample/ui/WearApp.kt
@@ -1,13 +1,29 @@
-// WearApp.kt
 package com.example.wearconnectivityexample.ui
 
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
-import androidx.wear.compose.navigation.rememberSwipeDismissableNavController
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.wear.compose.material.Button
+import androidx.wear.compose.material.Text
 import androidx.wear.compose.navigation.SwipeDismissableNavHost
 import androidx.wear.compose.navigation.composable
+import androidx.wear.compose.navigation.rememberSwipeDismissableNavController
 import androidx.navigation.navArgument
 import com.example.mywearosapp.ui.screens.ChatDetailScreen
 import com.example.wearconnectivityexample.ui.screens.RecordVoiceScreen
+import com.wearconnectivityexample.ui.components.ImageViewer
 import com.wearconnectivityexample.ui.screens.ChatListScreen
 
 @Composable
@@ -16,8 +32,16 @@ fun WearApp() {
 
     SwipeDismissableNavHost(
         navController = navController,
-        startDestination = "chatList"
+        startDestination = "menu",
     ) {
+        composable("menu") {
+            MenuScreen(
+                onChatListClick = { navController.navigate("chatList") },
+                onRecordClick = { navController.navigate("recordVoice") },
+                onCounterClick = { navController.navigate("counter") },
+                onImageViewerClick = { navController.navigate("imageViewer") }
+            )
+        }
         composable("chatList") {
             ChatListScreen(
                 onChatSelected = { phoneNumber ->
@@ -29,7 +53,8 @@ fun WearApp() {
             route = "chatDetail/{phoneNumber}",
             arguments = listOf(navArgument("phoneNumber") {})
         ) { backStackEntry ->
-            val phoneNumber = backStackEntry.arguments?.getString("phoneNumber") ?: ""
+            val phoneNumber =
+                backStackEntry.arguments?.getString("phoneNumber") ?: ""
             ChatDetailScreen(
                 phoneNumber = phoneNumber,
                 onRecordClick = { navController.navigate("recordVoice") }
@@ -37,11 +62,68 @@ fun WearApp() {
         }
         composable("recordVoice") {
             RecordVoiceScreen(
-                onStopRecording = {
-                    // Go back to the previous screen, or handle differently
-                    navController.popBackStack()
-                }
+                onStopRecording = { navController.popBackStack() }
             )
+        }
+        composable("counter") {
+            CounterScreen(onBack = { navController.popBackStack() })
+        }
+        composable("imageViewer") {
+            ImageViewerScreen(onBack = { navController.popBackStack() })
         }
     }
 }
+
+@Composable
+fun MenuScreen(
+    onChatListClick: () -> Unit,
+    onRecordClick: () -> Unit,
+    onCounterClick: () -> Unit,
+    onImageViewerClick: () -> Unit
+) {
+    Column(
+        modifier = Modifier.fillMaxSize(),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center
+    ) {
+        Button(onClick = onChatListClick) { Text("Chats") }
+        Spacer(modifier = Modifier.height(8.dp))
+        Button(onClick = onRecordClick) { Text("Record") }
+        Spacer(modifier = Modifier.height(8.dp))
+        Button(onClick = onCounterClick) { Text("Counter") }
+        Spacer(modifier = Modifier.height(8.dp))
+        Button(onClick = onImageViewerClick) { Text("Images") }
+    }
+}
+
+@Composable
+fun CounterScreen(onBack: () -> Unit) {
+    var count by remember { mutableStateOf(0) }
+    Column(
+        modifier = Modifier.fillMaxSize(),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center
+    ) {
+        Text(text = "Count: $count")
+        Spacer(modifier = Modifier.height(8.dp))
+        Button(onClick = { count++ }) { Text("Increase") }
+        Spacer(modifier = Modifier.height(8.dp))
+        Button(onClick = onBack) { Text("Back") }
+    }
+}
+
+@Composable
+fun ImageViewerScreen(onBack: () -> Unit) {
+    Box(modifier = Modifier.fillMaxSize()) {
+        ImageViewer()
+        Button(
+            onClick = onBack,
+            modifier = Modifier
+                .align(Alignment.TopStart)
+                .padding(8.dp)
+        ) {
+            Text("Back")
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- Start navigation from a new menu that links to chat list, recorder, counter, and image viewer screens
- Implement CounterScreen and ImageViewerScreen composables with explicit back actions
- Ensure navigation actions use `navController.popBackStack`

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b7077b12308320bcef58a0aca0d7ec