### PR TITLE
chore: align screen packages

### DIFF
--- a/app/src/main/java/com/wearconnectivityexample/ui/WearApp.kt
+++ b/app/src/main/java/com/wearconnectivityexample/ui/WearApp.kt
@@ -6,8 +6,8 @@ import androidx.wear.compose.navigation.rememberSwipeDismissableNavController
 import androidx.wear.compose.navigation.SwipeDismissableNavHost
 import androidx.wear.compose.navigation.composable
 import androidx.navigation.navArgument
-import com.example.mywearosapp.ui.screens.ChatDetailScreen
-import com.example.wearconnectivityexample.ui.screens.RecordVoiceScreen
+import com.wearconnectivityexample.ui.screens.ChatDetailScreen
+import com.wearconnectivityexample.ui.screens.RecordVoiceScreen
 import com.wearconnectivityexample.ui.screens.ChatListScreen
 
 @Composable

--- a/app/src/main/java/com/wearconnectivityexample/ui/screens/ChatDetailScreen.kt
+++ b/app/src/main/java/com/wearconnectivityexample/ui/screens/ChatDetailScreen.kt
@@ -1,4 +1,4 @@
-package com.example.mywearosapp.ui.screens
+package com.wearconnectivityexample.ui.screens
 
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.RoundedCornerShape

--- a/app/src/main/java/com/wearconnectivityexample/ui/screens/RecordVoiceScreen.kt
+++ b/app/src/main/java/com/wearconnectivityexample/ui/screens/RecordVoiceScreen.kt
@@ -1,4 +1,4 @@
-package com.example.wearconnectivityexample.ui.screens
+package com.wearconnectivityexample.ui.screens
 
 import android.content.Context
 import android.media.MediaRecorder


### PR DESCRIPTION
## Summary
- unify screen packages under `com.wearconnectivityexample.ui.screens`
- adjust WearApp imports to use the new package

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b7077dff208320b09ad8c15566cab7