### PR TITLE
feat: add recording state to chat screen

### DIFF
--- a/app/src/main/java/com/wearconnectivityexample/ui/WearApp.kt
+++ b/app/src/main/java/com/wearconnectivityexample/ui/WearApp.kt
@@ -7,7 +7,6 @@ import androidx.wear.compose.navigation.SwipeDismissableNavHost
 import androidx.wear.compose.navigation.composable
 import androidx.navigation.navArgument
 import com.example.mywearosapp.ui.screens.ChatDetailScreen
-import com.example.wearconnectivityexample.ui.screens.RecordVoiceScreen
 import com.wearconnectivityexample.ui.screens.ChatListScreen
 
 @Composable
@@ -31,16 +30,7 @@ fun WearApp() {
         ) { backStackEntry ->
             val phoneNumber = backStackEntry.arguments?.getString("phoneNumber") ?: ""
             ChatDetailScreen(
-                phoneNumber = phoneNumber,
-                onRecordClick = { navController.navigate("recordVoice") }
-            )
-        }
-        composable("recordVoice") {
-            RecordVoiceScreen(
-                onStopRecording = {
-                    // Go back to the previous screen, or handle differently
-                    navController.popBackStack()
-                }
+                phoneNumber = phoneNumber
             )
         }
     }

--- a/app/src/main/java/com/wearconnectivityexample/ui/screens/ChatDetailScreen.kt
+++ b/app/src/main/java/com/wearconnectivityexample/ui/screens/ChatDetailScreen.kt
@@ -5,19 +5,20 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Mic
 import androidx.compose.material3.Surface
-import androidx.compose.runtime.Composable
+import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import androidx.wear.compose.material.*
 import androidx.wear.compose.material.Text
+import com.example.wearconnectivityexample.ui.screens.RecordVoiceScreen
 
 @Composable
 fun ChatDetailScreen(
-    phoneNumber: String,
-    onRecordClick: () -> Unit
+    phoneNumber: String
 ) {
+    var isRecording by remember { mutableStateOf(false) }
     val listState = rememberScalingLazyListState()
     val messageList = listOf("Hello, How are you?", "I'm good. And you?", "I'm great. What did you do today?")
 
@@ -54,10 +55,35 @@ fun ChatDetailScreen(
                 }
             }
 
+            if (isRecording) {
+                item {
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 0.dp, vertical = 4.dp),
+                        horizontalArrangement = Arrangement.End
+                    ) {
+                        Surface(
+                            shape = RoundedCornerShape(16.dp),
+                            color = Color(0xFF97B1DA),
+                            modifier = Modifier
+                                .wrapContentWidth()
+                                .padding(0.dp)
+                        ) {
+                            Text(
+                                text = "Recording...",
+                                modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
+                                color = Color.Black
+                            )
+                        }
+                    }
+                }
+            }
+
             item {
                 // Record button at the bottom
                 Button(
-                    onClick = onRecordClick,
+                    onClick = { isRecording = true },
                     modifier = Modifier
                         .align(Alignment.BottomCenter)
                         .padding(bottom = 20.dp)
@@ -68,6 +94,10 @@ fun ChatDetailScreen(
                     )
                 }
             }
+        }
+
+        if (isRecording) {
+            RecordVoiceScreen(onStopRecording = { isRecording = false })
         }
     }
 }


### PR DESCRIPTION
## Summary
- manage recording state in chat detail screen and show "Recording..." message
- display RecordVoiceScreen overlay while recording and simplify navigation

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b7077f3dac8320970e1c6dba3d18f5