### PR TITLE
Add image screen with file sending and navigation

### DIFF
--- a/app/src/main/java/com/wearconnectivityexample/ui/WearApp.kt
+++ b/app/src/main/java/com/wearconnectivityexample/ui/WearApp.kt
@@ -9,6 +9,7 @@ import androidx.navigation.navArgument
 import com.example.mywearosapp.ui.screens.ChatDetailScreen
 import com.example.wearconnectivityexample.ui.screens.RecordVoiceScreen
 import com.wearconnectivityexample.ui.screens.ChatListScreen
+import com.wearconnectivityexample.ui.screens.ImageScreen
 
 @Composable
 fun WearApp() {
@@ -32,7 +33,8 @@ fun WearApp() {
             val phoneNumber = backStackEntry.arguments?.getString("phoneNumber") ?: ""
             ChatDetailScreen(
                 phoneNumber = phoneNumber,
-                onRecordClick = { navController.navigate("recordVoice") }
+                onRecordClick = { navController.navigate("recordVoice") },
+                onSendFileClick = { navController.navigate("imageScreen") }
             )
         }
         composable("recordVoice") {
@@ -42,6 +44,9 @@ fun WearApp() {
                     navController.popBackStack()
                 }
             )
+        }
+        composable("imageScreen") {
+            ImageScreen()
         }
     }
 }

--- a/app/src/main/java/com/wearconnectivityexample/ui/screens/ChatDetailScreen.kt
+++ b/app/src/main/java/com/wearconnectivityexample/ui/screens/ChatDetailScreen.kt
@@ -16,7 +16,8 @@ import androidx.wear.compose.material.Text
 @Composable
 fun ChatDetailScreen(
     phoneNumber: String,
-    onRecordClick: () -> Unit
+    onRecordClick: () -> Unit,
+    onSendFileClick: () -> Unit
 ) {
     val listState = rememberScalingLazyListState()
     val messageList = listOf("Hello, How are you?", "I'm good. And you?", "I'm great. What did you do today?")
@@ -55,17 +56,22 @@ fun ChatDetailScreen(
             }
 
             item {
-                // Record button at the bottom
-                Button(
-                    onClick = onRecordClick,
+                Column(
                     modifier = Modifier
-                        .align(Alignment.BottomCenter)
-                        .padding(bottom = 20.dp)
+                        .fillMaxWidth()
+                        .padding(bottom = 20.dp),
+                    horizontalAlignment = Alignment.CenterHorizontally
                 ) {
-                    Icon(
-                        imageVector = Icons.Default.Mic,
-                        contentDescription = "Record"
-                    )
+                    Button(onClick = onRecordClick) {
+                        Icon(
+                            imageVector = Icons.Default.Mic,
+                            contentDescription = "Record"
+                        )
+                    }
+                    Spacer(modifier = Modifier.height(8.dp))
+                    Button(onClick = onSendFileClick) {
+                        Text("Send File")
+                    }
                 }
             }
         }

--- a/app/src/main/java/com/wearconnectivityexample/ui/screens/ImageScreen.kt
+++ b/app/src/main/java/com/wearconnectivityexample/ui/screens/ImageScreen.kt
@@ -1,0 +1,72 @@
+package com.wearconnectivityexample.ui.screens
+
+import android.content.Context
+import android.util.Log
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
+import androidx.wear.compose.material.Button
+import androidx.wear.compose.material.Text
+import com.wearconnectivityexample.ui.components.ImageViewer
+import com.wearconnectivityexample.data.FileState
+import com.google.android.gms.wearable.Asset
+import com.google.android.gms.wearable.DataMap
+import com.google.android.gms.wearable.PutDataMapRequest
+import com.google.android.gms.wearable.Wearable
+import java.io.File
+import java.io.FileInputStream
+import java.io.IOException
+
+@Composable
+fun ImageScreen() {
+    val context = LocalContext.current
+    Box(modifier = Modifier.fillMaxSize()) {
+        ImageViewer()
+        Button(
+            onClick = { sendImageFile(context) },
+            modifier = Modifier.align(Alignment.BottomCenter).padding(bottom = 20.dp)
+        ) {
+            Text("Send File")
+        }
+    }
+}
+
+fun sendImageFile(context: Context) {
+    val path = FileState.imagePath ?: return
+    val file = File(path)
+    if (!file.exists()) return
+
+    val asset = try {
+        FileInputStream(file).use { fis ->
+            val bytes = ByteArray(file.length().toInt())
+            fis.read(bytes)
+            Asset.createFromBytes(bytes)
+        }
+    } catch (e: IOException) {
+        Log.e("ImageScreen", "Error creating asset", e)
+        return
+    }
+
+    val dataMapRequest = PutDataMapRequest.create("/file_transfer")
+    dataMapRequest.dataMap.putAsset("file", asset)
+    val metadata = DataMap().apply {
+        putString("fileName", file.name)
+        putString("fileType", file.extension)
+    }
+    dataMapRequest.dataMap.putDataMap("metadata", metadata)
+    dataMapRequest.dataMap.putLong("timestamp", System.currentTimeMillis())
+
+    val request = dataMapRequest.asPutDataRequest()
+    Wearable.getDataClient(context).putDataItem(request)
+        .addOnSuccessListener { dataItem ->
+            Log.i("ImageScreen", "Image sent successfully: $dataItem")
+        }
+        .addOnFailureListener { e ->
+            Log.e("ImageScreen", "Failed to send image", e)
+        }
+}


### PR DESCRIPTION
## Summary
- show received images with delete and send capabilities
- wire up navigation route and menu button to access image screen

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b70780062c8320bc4e3ad80857dbc3