### PR TITLE
Add instrumentation tests and CI for Wear OS communication

### DIFF
--- a/.github/workflows/android-instrumentation.yml
+++ b/.github/workflows/android-instrumentation.yml
@@ -1,0 +1,34 @@
+name: Android Integration Tests
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  instrumentation:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+          cache: gradle
+
+      - name: Gradle permissions
+        run: chmod +x gradlew
+
+      - name: Run instrumented tests
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: 33
+          target: google_apis
+          arch: x86_64
+          profile: wearos
+          script: ./gradlew connectedDebugAndroidTest

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -16,6 +16,7 @@ android {
         vectorDrawables {
             useSupportLibrary = true
         }
+        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 
     signingConfigs {
@@ -77,6 +78,10 @@ dependencies {
 
     androidTestImplementation(platform("androidx.compose:compose-bom:2023.08.00"))
     androidTestImplementation("androidx.compose.ui:ui-test-junit4")
+    androidTestImplementation("androidx.test.core:core-ktx:1.5.0")
+    androidTestImplementation("androidx.test.ext:junit:1.1.5")
+    androidTestImplementation("androidx.test:runner:1.5.2")
+    androidTestImplementation("androidx.test:rules:1.5.0")
     debugImplementation("androidx.compose.ui:ui-tooling")
     debugImplementation("androidx.compose.ui:ui-test-manifest")
 }

--- a/app/src/androidTest/java/com/wearconnectivityexample/service/VoiceMessageCommunicationTest.kt
+++ b/app/src/androidTest/java/com/wearconnectivityexample/service/VoiceMessageCommunicationTest.kt
@@ -1,0 +1,96 @@
+package com.wearconnectivityexample.service
+
+import android.content.Context
+import android.net.Uri
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.google.android.gms.tasks.Tasks
+import com.google.android.gms.wearable.Asset
+import com.google.android.gms.wearable.DataClient
+import com.google.android.gms.wearable.DataItem
+import com.google.android.gms.wearable.DataItemAsset
+import com.google.android.gms.wearable.PutDataRequest
+import com.wearconnectivityexample.ui.screens.createVoiceMessageDataMap
+import com.wearconnectivityexample.ui.screens.sendVoiceMessage
+import java.io.File
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class VoiceMessageCommunicationTest {
+
+    private lateinit var context: Context
+    private lateinit var tempFile: File
+
+    @Before
+    fun setUp() {
+        context = ApplicationProvider.getApplicationContext()
+        tempFile = File.createTempFile("voice", ".mp3", context.cacheDir)
+        tempFile.writeText("sample-data")
+    }
+
+    @After
+    fun tearDown() {
+        if (tempFile.exists()) {
+            tempFile.delete()
+        }
+    }
+
+    @Test
+    fun createVoiceMessageDataMap_containsMetadataAndAsset() {
+        val timestamp = 1_234L
+
+        val request = createVoiceMessageDataMap(tempFile) { timestamp }
+
+        val dataMap = request.dataMap
+        val metadata = dataMap.getDataMap("metadata")
+        assertNotNull("Metadata should be present", metadata)
+        assertEquals(tempFile.name, metadata?.getString("fileName"))
+        assertEquals(tempFile.extension, metadata?.getString("fileType"))
+        assertNotNull("Asset should be attached", dataMap.getAsset("file"))
+        assertEquals(timestamp, dataMap.getLong("timestamp"))
+    }
+
+    @Test
+    fun sendVoiceMessage_dispatchesRequestToClient() {
+        val fakeClient = RecordingWearDataClient()
+
+        sendVoiceMessage(context, tempFile.absolutePath, fakeClient) { 9_876L }
+
+        val request = fakeClient.lastRequest
+        assertNotNull("PutDataRequest should be created", request)
+        assertEquals("/file_transfer", request?.uri?.path)
+    }
+}
+
+private class RecordingWearDataClient : WearDataClient {
+    var lastRequest: PutDataRequest? = null
+
+    override fun putDataItem(request: PutDataRequest): com.google.android.gms.tasks.Task<DataItem> {
+        lastRequest = request
+        return Tasks.forResult(FakeDataItem(request.uri))
+    }
+
+    override fun getFdForAsset(asset: Asset): com.google.android.gms.tasks.Task<DataClient.GetFdForAssetResponse> {
+        throw UnsupportedOperationException("Not needed for this test")
+    }
+}
+
+private class FakeDataItem(private val uri: Uri) : DataItem {
+    private var data: ByteArray? = null
+
+    override fun getUri(): Uri = uri
+
+    override fun setData(data: ByteArray?): DataItem {
+        this.data = data
+        return this
+    }
+
+    override fun getData(): ByteArray? = data
+
+    override fun getAssets(): MutableMap<String, DataItemAsset> = mutableMapOf()
+}

--- a/app/src/androidTest/java/com/wearconnectivityexample/service/WearAssetHandlerTest.kt
+++ b/app/src/androidTest/java/com/wearconnectivityexample/service/WearAssetHandlerTest.kt
@@ -1,0 +1,83 @@
+package com.wearconnectivityexample.service
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.google.android.gms.tasks.Tasks
+import com.google.android.gms.wearable.Asset
+import com.google.android.gms.wearable.DataClient
+import com.google.android.gms.wearable.DataItem
+import com.google.android.gms.wearable.PutDataRequest
+import java.io.ByteArrayInputStream
+import java.io.File
+import java.io.InputStream
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import org.junit.After
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class WearAssetHandlerTest {
+
+    private lateinit var context: Context
+    private lateinit var handler: WearAssetHandler
+    private lateinit var createdFiles: MutableList<File>
+
+    @Before
+    fun setUp() {
+        context = ApplicationProvider.getApplicationContext()
+        createdFiles = mutableListOf()
+    }
+
+    @After
+    fun tearDown() {
+        createdFiles.forEach { file ->
+            if (file.exists()) {
+                file.delete()
+            }
+        }
+    }
+
+    @Test
+    fun saveReceivedFile_persistsPayloadAndInvokesCallback() {
+        val payload = "wear-data".toByteArray()
+        val asset = Asset.createFromBytes(payload)
+        val fileName = "received_test.bin"
+        val fakeClient = AssetProvidingWearDataClient(payload)
+        handler = WearAssetHandler(dataClientProvider = { fakeClient }, targetFileName = { fileName })
+
+        val latch = CountDownLatch(1)
+        var savedPath: String? = null
+
+        handler.saveReceivedFile(context, asset) { path ->
+            savedPath = path
+            latch.countDown()
+        }
+
+        assertTrue("Callback should be invoked", latch.await(5, TimeUnit.SECONDS))
+        val actualPath = savedPath
+        assertTrue("Saved path should not be null", actualPath != null)
+        val savedFile = File(actualPath!!)
+        createdFiles.add(savedFile)
+        assertTrue("File should exist", savedFile.exists())
+        assertArrayEquals(payload, savedFile.readBytes())
+    }
+}
+
+private class AssetProvidingWearDataClient(private val bytes: ByteArray) : WearDataClient {
+    override fun putDataItem(request: PutDataRequest): com.google.android.gms.tasks.Task<DataItem> {
+        throw UnsupportedOperationException("Not used in this test")
+    }
+
+    override fun getFdForAsset(asset: Asset): com.google.android.gms.tasks.Task<DataClient.GetFdForAssetResponse> {
+        return Tasks.forResult(object : DataClient.GetFdForAssetResponse {
+            override fun getInputStream(): InputStream = ByteArrayInputStream(bytes)
+
+            override fun getParcelFileDescriptor(): android.os.ParcelFileDescriptor? = null
+        })
+    }
+}

--- a/app/src/androidTest/java/com/wearconnectivityexample/ui/WearAppNavigationTest.kt
+++ b/app/src/androidTest/java/com/wearconnectivityexample/ui/WearAppNavigationTest.kt
@@ -1,0 +1,35 @@
+package com.wearconnectivityexample.ui
+
+import android.Manifest
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.rule.GrantPermissionRule
+import com.example.wearconnectivityexample.ui.MainActivity
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class WearAppNavigationTest {
+
+    @get:Rule(order = 0)
+    val permissionRule: GrantPermissionRule =
+        GrantPermissionRule.grant(Manifest.permission.RECORD_AUDIO)
+
+    @get:Rule(order = 1)
+    val composeRule = createAndroidComposeRule<MainActivity>()
+
+    @Test
+    fun navigateFromChatListToRecordScreen() {
+        composeRule.onNodeWithText("08131372751").assertExists().performClick()
+
+        composeRule.onNodeWithText("Hello, How are you?").assertExists()
+
+        composeRule.onNodeWithContentDescription("Record").assertExists().performClick()
+
+        composeRule.onNodeWithText("Record Voice").assertExists()
+    }
+}

--- a/app/src/main/java/com/wearconnectivityexample/service/WearDataClient.kt
+++ b/app/src/main/java/com/wearconnectivityexample/service/WearDataClient.kt
@@ -1,0 +1,27 @@
+package com.wearconnectivityexample.service
+
+import android.content.Context
+import com.google.android.gms.wearable.Asset
+import com.google.android.gms.wearable.DataClient
+import com.google.android.gms.wearable.DataItem
+import com.google.android.gms.wearable.PutDataRequest
+import com.google.android.gms.wearable.Wearable
+import com.google.android.gms.tasks.Task
+
+/**
+ * Minimal abstraction over [DataClient] to make the wearable communication layer testable.
+ */
+interface WearDataClient {
+    fun putDataItem(request: PutDataRequest): Task<DataItem>
+    fun getFdForAsset(asset: Asset): Task<DataClient.GetFdForAssetResponse>
+}
+
+class GoogleWearDataClient(private val delegate: DataClient) : WearDataClient {
+    override fun putDataItem(request: PutDataRequest): Task<DataItem> = delegate.putDataItem(request)
+
+    override fun getFdForAsset(asset: Asset): Task<DataClient.GetFdForAssetResponse> =
+        delegate.getFdForAsset(asset)
+}
+
+fun defaultWearDataClient(context: Context): WearDataClient =
+    GoogleWearDataClient(Wearable.getDataClient(context))

--- a/app/src/main/java/com/wearconnectivityexample/service/WearDataListenerService.kt
+++ b/app/src/main/java/com/wearconnectivityexample/service/WearDataListenerService.kt
@@ -1,16 +1,18 @@
 package com.wearconnectivityexample.service
 
+import android.content.Context
 import android.util.Log
 import com.google.android.gms.wearable.Asset
 import com.google.android.gms.wearable.DataEvent
 import com.google.android.gms.wearable.DataEventBuffer
 import com.google.android.gms.wearable.DataMapItem
-import com.google.android.gms.wearable.Wearable
 import com.google.android.gms.wearable.WearableListenerService
 import com.wearconnectivityexample.data.FileState
 import java.io.File
 
 class WearDataListenerService : WearableListenerService() {
+    internal var assetHandler: WearAssetHandler = WearAssetHandler()
+
     override fun onDataChanged(dataEvents: DataEventBuffer) {
         for (event in dataEvents) {
             if (event.type == DataEvent.TYPE_CHANGED) {
@@ -18,25 +20,33 @@ class WearDataListenerService : WearableListenerService() {
                 if (dataItem.uri.path == "/file_transfer") {
                     val asset = DataMapItem.fromDataItem(dataItem).dataMap.getAsset("file")
                     if (asset != null) {
-                        saveReceivedFile(asset)
+                        assetHandler.saveReceivedFile(this, asset)
                     }
                 }
             }
         }
     }
+}
 
-    fun saveReceivedFile(asset: Asset) {
-        val dataClient = Wearable.getDataClient(this)
+class WearAssetHandler(
+    private val dataClientProvider: (Context) -> WearDataClient = { defaultWearDataClient(it) },
+    private val targetFileName: () -> String = { "received_file.jpg" }
+) {
+    fun saveReceivedFile(
+        context: Context,
+        asset: Asset,
+        onFileSaved: (String) -> Unit = { savedPath -> FileState.imagePath = savedPath }
+    ) {
+        val dataClient = dataClientProvider(context)
         val task = dataClient.getFdForAsset(asset)
 
         task.addOnSuccessListener { response ->
             response.inputStream.use { inputStream ->
-                val file = File(filesDir, "received_file.jpg")
+                val file = File(context.filesDir, targetFileName())
                 file.outputStream().use { outputStream ->
                     inputStream.copyTo(outputStream)
                 }
-                // Update the shared state (ensure this runs on the main thread)
-                FileState.imagePath = file.absolutePath
+                onFileSaved(file.absolutePath)
             }
             Log.w("WearOS", "File transfer successful")
         }.addOnFailureListener { e ->

--- a/app/src/main/java/com/wearconnectivityexample/ui/screens/RecordVoiceScreen.kt
+++ b/app/src/main/java/com/wearconnectivityexample/ui/screens/RecordVoiceScreen.kt
@@ -6,40 +6,43 @@ import android.util.Log
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.wrapContentSize
-import androidx.compose.runtime.*
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.unit.dp
-import androidx.wear.compose.material.Chip
-import androidx.wear.compose.material.ChipDefaults
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.wear.compose.material.Icon
 import androidx.wear.compose.material.Text
 import androidx.wear.compose.material.ToggleButton
 import androidx.wear.compose.material.ToggleButtonDefaults
 import com.google.android.gms.wearable.Asset
+import com.google.android.gms.wearable.DataMap
 import com.google.android.gms.wearable.PutDataMapRequest
-import com.google.android.gms.wearable.Wearable
+import com.wearconnectivityexample.R
+import com.wearconnectivityexample.service.WearDataClient
+import com.wearconnectivityexample.service.defaultWearDataClient
 import java.io.File
 import java.io.FileInputStream
 import java.io.IOException
-import androidx.wear.compose.material.Icon
-import androidx.wear.compose.material.ToggleButton
-import com.wearconnectivityexample.R
-import androidx.wear.compose.material.Text
-import com.google.android.gms.wearable.DataMap
 
 @Composable
 fun RecordVoiceScreen(
-    onStopRecording: () -> Unit
+    onStopRecording: () -> Unit,
+    recorderProvider: () -> MediaRecorder = ::MediaRecorder,
+    messageSender: (Context, String) -> Unit = { context, filePath ->
+        sendVoiceMessage(context, filePath)
+    }
 ) {
     val context = LocalContext.current
 
@@ -52,7 +55,7 @@ fun RecordVoiceScreen(
 
     // Function to start recording.
     fun startRecording() {
-        val recorder = MediaRecorder().apply {
+        val recorder = recorderProvider().apply {
             setAudioSource(MediaRecorder.AudioSource.MIC)
             setOutputFormat(MediaRecorder.OutputFormat.MPEG_4)
             setAudioEncoder(MediaRecorder.AudioEncoder.AAC)
@@ -78,7 +81,7 @@ fun RecordVoiceScreen(
             }
             mediaRecorder = null
             isRecording = false
-            sendVoiceMessage(context, outputFile)
+            messageSender(context, outputFile)
             onStopRecording();
         } catch (e: Exception) {
             Log.e("RecordVoiceScreen", "Error stopping recorder", e)
@@ -99,31 +102,19 @@ fun RecordVoiceScreen(
 /**
  * Sends the voice message file using the DataClient API.
  */
-fun sendVoiceMessage(context: Context, filePath: String) {
+fun sendVoiceMessage(
+    context: Context,
+    filePath: String,
+    dataClient: WearDataClient = defaultWearDataClient(context),
+    timestampProvider: () -> Long = System::currentTimeMillis
+) {
     val file = File(filePath)
-    val fileName = file.name // Extract the original filename (e.g., "voice_message.mp3")
-    val fileExtension = file.extension // Extract file type (e.g., "mp3", "wav")
-    val dataClient = Wearable.getDataClient(context)
-    val asset = try {
-        FileInputStream(file).use { fis ->
-            val bytes = ByteArray(file.length().toInt())
-            fis.read(bytes)
-            Asset.createFromBytes(bytes)
-        }
-    } catch (e: IOException) {
-        Log.e("RecordVoiceScreen", "Error creating asset", e)
+    val dataMapRequest = try {
+        createVoiceMessageDataMap(file, timestampProvider)
+    } catch (ioException: IOException) {
+        Log.e("RecordVoiceScreen", "Failed to prepare voice message asset", ioException)
         return
     }
-    val dataMapRequest = PutDataMapRequest.create("/file_transfer")
-    dataMapRequest.dataMap.putAsset("file", asset)
-    // Include metadata similar to Watch Connectivity API
-    // https://github.com/watch-connectivity/react-native-watch-connectivity/blob/f22da8191ec75daeaecb7a80a65b6c0a87f7d72b/ios/RNWatch/RNWatch.m#L466
-    val metadata = DataMap()
-    metadata.putString("fileName", fileName)
-    metadata.putString("fileType", fileExtension)
-    dataMapRequest.dataMap.putDataMap("metadata", metadata)
-
-    dataMapRequest.dataMap.putLong("timestamp", System.currentTimeMillis())
     val request = dataMapRequest.asPutDataRequest()
     dataClient.putDataItem(request)
         .addOnSuccessListener { dataItem ->
@@ -164,5 +155,32 @@ fun RecordComponent(onRecordClicked: () -> Unit, checked: Boolean) {
                 )
             }
         }
+    }
+}
+
+fun createVoiceMessageDataMap(
+    file: File,
+    timestampProvider: () -> Long
+): PutDataMapRequest {
+    val fileName = file.name
+    val fileExtension = file.extension
+    val asset = try {
+        FileInputStream(file).use { fis ->
+            val bytes = ByteArray(file.length().toInt())
+            fis.read(bytes)
+            Asset.createFromBytes(bytes)
+        }
+    } catch (e: IOException) {
+        Log.e("RecordVoiceScreen", "Error creating asset", e)
+        throw e
+    }
+    return PutDataMapRequest.create("/file_transfer").apply {
+        dataMap.putAsset("file", asset)
+        val metadata = DataMap().apply {
+            putString("fileName", fileName)
+            putString("fileType", fileExtension)
+        }
+        dataMap.putDataMap("metadata", metadata)
+        dataMap.putLong("timestamp", timestampProvider())
     }
 }


### PR DESCRIPTION
## Summary
- configure the Android test instrumentation runner and dependencies needed for UI and integration testing
- introduce a thin Wear OS data client abstraction and refactor voice recording and listener code for testability
- add instrumentation test suites for navigation and communication flows plus a GitHub Actions workflow to run them on CI

## Testing
- `./gradlew compileDebugAndroidTestKotlin` *(fails locally because the Android SDK is not configured in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68fbd217248c8320a86728cfa6b07709